### PR TITLE
Retire /recipes subpath (site moved to recipes.4craftybrothers.com)

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
-  # Fired by the heckerdj/recipes repo when new recipes are published,
-  # so danhecker.com/recipes stays in sync without a resume change.
-  repository_dispatch:
-    types: [recipes-updated]
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -46,19 +42,6 @@ jobs:
         
       - name: Build React app
         run: pnpm run build
-
-      # Serve the family recipe site at danhecker.com/recipes.
-      # continue-on-error: a recipes hiccup must never block a resume deploy
-      # (worst case /recipes is briefly stale or missing, the resume is fine).
-      - name: Add family recipe site at /recipes
-        continue-on-error: true
-        run: |
-          git clone --depth 1 https://github.com/heckerdj/recipes.git /tmp/recipes-site
-          mkdir -p dist/recipes
-          rsync -a /tmp/recipes-site/ dist/recipes/ \
-            --exclude .git --exclude node_modules --exclude source --exclude scripts \
-            --exclude package.json --exclude package-lock.json \
-            --exclude README.md --exclude .gitignore
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/public/recipes/index.html
+++ b/public/recipes/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="0; url=https://recipes.4craftybrothers.com/">
+  <title>Recipes have moved</title>
+</head>
+<body>
+  <p>The family recipe book moved to
+    <a href="https://recipes.4craftybrothers.com/">recipes.4craftybrothers.com</a>.
+  </p>
+</body>
+</html>

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -22,12 +22,10 @@ const projects: Project[] = [
   },
   {
     title: 'Family Recipe Site',
-    description: 'The family recipe box, digitized. A fully static, backend-free site on GitHub Pages: photos of recipe cards are transcribed with Claude vision, compiled from markdown into JSON, and published with ingredients, time, effort, and cuisine search alongside scans of the original cards.',
-    technologies: ['JavaScript', 'Node.js', 'GitHub Pages' ],
-    link: 'https://danhecker.com/recipes/',
-    linkLabel: 'View Site',
-    secondaryLink: 'https://github.com/heckerdj/recipes',
-    secondaryLinkLabel: 'GitHub',
+    description: 'The family recipe box, digitized into a private multi-user app. Photos of recipe cards are transcribed with Claude vision through an automated ingestion pipeline, then served as a static site on Cloudflare Pages behind Cloudflare Access (email OTP for family members), with per-user likes and photo uploads powered by Workers, D1, and R2 — all on free tiers.',
+    technologies: ['JavaScript', 'Node.js', 'Cloudflare Pages', 'Cloudflare Workers', 'D1', 'R2', 'Claude API'],
+    link: 'https://recipes.4craftybrothers.com/',
+    linkLabel: 'Site (family sign-in)',
     status: 'Live'
   },
   {

--- a/src/test/Projects.test.tsx
+++ b/src/test/Projects.test.tsx
@@ -26,13 +26,11 @@ describe('Projects', () => {
     expect(screen.getByText(/The family recipe box, digitized/)).toBeInTheDocument()
   })
 
-  it('renders Family Recipe Box project with both site and GitHub links', () => {
+  it('renders Family Recipe Site link to the gated family domain', () => {
     render(<Projects />)
-    const siteLink = screen.getByText('View Site')
-    const gitHubLink = screen.getByText('GitHub')
+    const siteLink = screen.getByText('Site (family sign-in)')
 
-    expect(siteLink).toHaveAttribute('href', 'https://danhecker.com/recipes/')
-    expect(gitHubLink).toHaveAttribute('href', 'https://github.com/heckerdj/recipes')
+    expect(siteLink).toHaveAttribute('href', 'https://recipes.4craftybrothers.com/')
   })
 
   it('renders 3D Printing project', () => {
@@ -55,14 +53,13 @@ describe('Projects', () => {
     const viewLinks = screen.getAllByText('View Project')
     const makerWorldLink = screen.getByText('MakerWorld')
     const printablesLink = screen.getByText('Printables')
-    const siteLink = screen.getByText('View Site')
-    const gitHubLink = screen.getByText('GitHub')
+    const siteLink = screen.getByText('Site (family sign-in)')
 
     // Check that "View Project" appears for projects without secondaryLink
     expect(viewLinks).toHaveLength(2)
 
     // Check all links have correct attributes
-    const allLinks = [...viewLinks, makerWorldLink, printablesLink, siteLink, gitHubLink]
+    const allLinks = [...viewLinks, makerWorldLink, printablesLink, siteLink]
     allLinks.forEach(link => {
       expect(link).toHaveAttribute('target', '_blank')
       expect(link).toHaveAttribute('rel', 'noopener noreferrer')


### PR DESCRIPTION
The recipe book now lives on Cloudflare Pages behind Cloudflare Access at recipes.4craftybrothers.com. This removes the recipes copy step + dispatch trigger and adds a redirect stub at /recipes.

Merge when ready — after this merges, the recipes repo goes private (its public clone in the removed step would have started failing anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)