### PR TITLE
Make SonarQube CI job non-blocking (expired SONAR_TOKEN)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,14 +34,20 @@ jobs:
   sonarqube:
     name: SonarQube
     runs-on: ubuntu-latest
+    # Non-blocking: SonarCloud is a nice-to-have. A missing/expired SONAR_TOKEN
+    # (or a SonarCloud outage) should not fail the overall checks — CodeQL above
+    # still gates security scanning. Remove continue-on-error once SONAR_TOKEN
+    # is valid if you want Sonar failures to block again.
+    continue-on-error: true
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-          
+
       - name: SonarQube Scan
+        continue-on-error: true
         uses: SonarSource/sonarqube-scan-action@v6
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
The SonarCloud scan fails with HTTP 403 (expired/invalid SONAR_TOKEN), turning green pushes red even though build, tests, deploy, and CodeQL all pass. This marks the Sonar job + step `continue-on-error: true` so it can't fail the overall checks. CodeQL still gates security scanning.

Proper fix (separate, when convenient): refresh SONAR_TOKEN in SonarCloud and update the repo secret, then optionally revert this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)